### PR TITLE
Обновление index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@
 						</li>
 
 						<li class="nav-item d-lg-none">
-							<a href="https://github.com/Linux4Yourself/Linux4Yourself.Book"
+							<a href="https://github.com/Linux4Yourself"
 								class="text-white p-2 d-inline-block">
 								Репозиторий Github
 							</a>


### PR DESCRIPTION
Так как 'Репозиторий GitHub' включает в себя не только core-книгу, укоротил ссылку до `https://github.com/Linux4Yourself`.